### PR TITLE
Seurat merge without data slots

### DIFF
--- a/pipeline-runner/R/qc-6-integrate_scdata.R
+++ b/pipeline-runner/R/qc-6-integrate_scdata.R
@@ -112,7 +112,7 @@ merge_scdata_list <- function(scdata_list) {
   if (length(scdata_list) == 1) {
     scdata <- scdata_list[[1]]
   } else {
-    scdata <- merge(scdata_list[[1]], y = scdata_list[-1])
+    scdata <- merge(scdata_list[[1]], y = scdata_list[-1], merge.data = FALSE)
   }
 
   return(scdata)


### PR DESCRIPTION
# Description
Seurat contains two slots per assay, $data and $counts. In our case, they are exactly the same data but it's duplicated, so when we run merge, both of them are merged separately, leading to x2 memory requirements increase. Disabling the merge.data option leads to half memory used.

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-2124

#### Link to staging deployment URL (or set N/A)
https://ui-german-pipeline23.scp-staging.biomage.net/data-management

#### Links to any PRs or resources related to this PR

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in biomage-org/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [x] Relevant Github READMEs updated **or** no GitHub README updates required.
- [x] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [x] Photo of a cute animal attached to this PR.

Extremely random I was looking for a slow animal picture (referring to seurat being stupid) and got this

![image](https://user-images.githubusercontent.com/2961095/189627361-e71864a3-18a7-4b70-81cb-71e131f49718.png)
