### PR TITLE
add empty scratchpad to subset cellsets

### DIFF
--- a/pipeline-runner/R/gem2s-7-upload_to_aws.R
+++ b/pipeline-runner/R/gem2s-7-upload_to_aws.R
@@ -311,8 +311,16 @@ get_subset_cell_sets <- function(scdata_list, input, prev_out, disable_qc_filter
   if ("scratchpad" %in% unique(subset_cellsets$type)) {
     message("adding custom cellsets to subset experiment")
     scratchpad_cellsets <- build_scratchpad_cellsets(color_pool, subset_cellsets)
-    cell_sets <- c(cell_sets, list(scratchpad_cellsets))
+  } else {
+    scratchpad_cellsets <- list(
+      key = "scratchpad",
+      name = "Custom cell sets",
+      rootNode = TRUE,
+      children = list(),
+      type = "cellSets"
+    )
   }
+  cell_sets <- c(cell_sets, list(scratchpad_cellsets))
 
   cell_sets <- list(cellSets = cell_sets)
 


### PR DESCRIPTION
# Description
Cellsets must always contain a scratchpad slot. Subset experiments whose parents did not contain custom cellsets (or where all cells in custom cellsets were subsetted out), so we need to add the empty scratchapd slot, like we do in the `get_cellsets_function`.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in biomage-org/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
